### PR TITLE
Fix for changes to b2_authorize_account and b2_list_buckets.

### DIFF
--- a/b2.go
+++ b/b2.go
@@ -236,7 +236,7 @@ func (c *Client) doRequest(endpoint string, params map[string]interface{}) (*htt
 		return nil, err
 	}
 	// Reduce debug log noise
-	delete(params, "accountID")
+	// delete(params, "accountID")
 	delete(params, "bucketID")
 
 	apiURL := c.loginInfo.Load().(*LoginInfo).ApiURL
@@ -298,7 +298,7 @@ func (c *Client) BucketByID(id string) *Bucket {
 // found and createIfNotExists is true, CreateBucket is called with allPublic set
 // to false. Otherwise, an error is returned.
 func (c *Client) BucketByName(name string, createIfNotExists bool) (*BucketInfo, error) {
-	bs, err := c.Buckets()
+	bs, err := c.Buckets(name)
 	if err != nil {
 		return nil, err
 	}
@@ -314,9 +314,10 @@ func (c *Client) BucketByName(name string, createIfNotExists bool) (*BucketInfo,
 }
 
 // Buckets returns a list of buckets sorted by name.
-func (c *Client) Buckets() ([]*BucketInfo, error) {
+func (c *Client) Buckets(name string) ([]*BucketInfo, error) {
 	res, err := c.doRequest("b2_list_buckets", map[string]interface{}{
 		"accountId": c.loginInfo.Load().(*LoginInfo).AccountID,
+		"bucketName": name,
 	})
 	if err != nil {
 		return nil, err

--- a/b2.go
+++ b/b2.go
@@ -316,7 +316,7 @@ func (c *Client) BucketByName(name string, createIfNotExists bool) (*BucketInfo,
 // Buckets returns a list of buckets sorted by name.
 func (c *Client) Buckets() ([]*BucketInfo, error) {
 	res, err := c.doRequest("b2_list_buckets", map[string]interface{}{
-		"accountId": c.LoginInfo.AccountID,
+		"accountId": c.loginInfo.Load().(*LoginInfo).AccountID,
 	})
 	if err != nil {
 		return nil, err
@@ -352,7 +352,7 @@ func (c *Client) CreateBucket(name string, allPublic bool) (*BucketInfo, error) 
 		bucketType = "allPublic"
 	}
 	res, err := c.doRequest("b2_create_bucket", map[string]interface{}{
-		"accountId":  c.LoginInfo.AccountID,
+		"accountId":  c.loginInfo.Load().(*LoginInfo).AccountID,
 		"bucketName": name,
 		"bucketType": bucketType,
 	})
@@ -379,7 +379,7 @@ func (c *Client) CreateBucket(name string, allPublic bool) (*BucketInfo, error) 
 // becomes invalid and any other calls will fail.
 func (b *Bucket) Delete() error {
 	res, err := b.c.doRequest("b2_delete_bucket", map[string]interface{}{
-		"accountId": b.c.LoginInfo.AccountID,
+		"accountId": b.c.loginInfo.Load().(*LoginInfo).AccountID,
 		"bucketId":  b.ID,
 	})
 	if err != nil {

--- a/b2.go
+++ b/b2.go
@@ -316,7 +316,7 @@ func (c *Client) BucketByName(name string, createIfNotExists bool) (*BucketInfo,
 // Buckets returns a list of buckets sorted by name.
 func (c *Client) Buckets() ([]*BucketInfo, error) {
 	res, err := c.doRequest("b2_list_buckets", map[string]interface{}{
-		"accountId": c.accountID,
+		"accountId": c.LoginInfo.AccountID,
 	})
 	if err != nil {
 		return nil, err
@@ -352,7 +352,7 @@ func (c *Client) CreateBucket(name string, allPublic bool) (*BucketInfo, error) 
 		bucketType = "allPublic"
 	}
 	res, err := c.doRequest("b2_create_bucket", map[string]interface{}{
-		"accountId":  c.accountID,
+		"accountId":  c.LoginInfo.AccountID,
 		"bucketName": name,
 		"bucketType": bucketType,
 	})
@@ -379,7 +379,7 @@ func (c *Client) CreateBucket(name string, allPublic bool) (*BucketInfo, error) 
 // becomes invalid and any other calls will fail.
 func (b *Bucket) Delete() error {
 	res, err := b.c.doRequest("b2_delete_bucket", map[string]interface{}{
-		"accountId": b.c.accountID,
+		"accountId": b.c.LoginInfo.AccountID,
 		"bucketId":  b.ID,
 	})
 	if err != nil {


### PR DESCRIPTION
Due to changes to Backblazes api, you need to use the Application Key ID to authorize an account but still use the AccountID to list buckets.  Also, you have to specific the name of the bucket if the authorization key restricts access to one bucket or you will get "unauthorized" returned.

This PR fixes these issues.